### PR TITLE
Added requirements for starting the notebook.

### DIFF
--- a/read_me.txt
+++ b/read_me.txt
@@ -1,10 +1,15 @@
 read me
 
+1. Install the requirements:
+    $ pip install -r requirements.txt
 
-1. Run the script entitled 'model_spectra_download.py'. This will download the 10640 model spectra files from Vizie-R directly to the folder called 'model_spectra'.
+1. Run the script entitled 'model_spectra_download.py'.
+    $ python model_spectra_download.py
+This will download the 10640 model spectra files from Vizie-R directly to the folder called 'model_spectra'.
 
-2. Once this has run, you can open the CMD_toolkit Jupyter notebook. 
+2. Trust and then start the jupyter notebook CMD_toolkit:
+    $ jupyter trust CMD_toolkit.ipynb
+    $ jupyter notebook CMD_toolkit.ipynb
 
 3. Click 'toggle code' to hide the blocks of code and interact with the notebook using HTML widgets.
-
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+jupyter
+matplotlib
+numpy
+requests


### PR DESCRIPTION
The notebook has a number of requirements that it depends on. These need to be installed before it can be run. On a fresh install of Python I needed to install:
- jupyter
- matplotlib
- numpy
- requests

I've added these to a standard requirements.txt and have added an initial step to the README to say that the required packages can be installed using the standard command: `pip install -r requirements.txt`

With this change I was able to run the notebook and generate a plot!
